### PR TITLE
Resolves #59 - Explain markdown is supported in event description

### DIFF
--- a/data/events/new.njk
+++ b/data/events/new.njk
@@ -25,7 +25,7 @@
     {{textInput('title', 'Título', required)}}
     {{dateInput('startDate', 'Fecha', required)}}
     {{timeInput('startTime', 'Hora', required, 'Formato hh:mm. Si el control pide tres valores, el tercer valor establece AM o PM.')}}
-    {{textArea('description', 'Descripción', required)}}
+    {{textArea('description', 'Descripción', required, '', 'Admite el uso de Markdown', 'https://www.markdownguide.org/cheat-sheet/')}}
     {{textInput('sourceUrl', 'Link', required)}}
     {{textInput('hashtag', 'Usuario de twitter', notRequired, 'Por ejemplo: @vlctechhub. Si no tienes usuario de twitter puedes usar un hashtag como por ejemplo #eventoparatodos. De aquí se genera la imagen cuando se publique el evento.')}}
     <button type="button" class="button button-emphasis" data-type="submit">Enviar el evento</button>

--- a/templates/macros/form.njk
+++ b/templates/macros/form.njk
@@ -10,7 +10,7 @@
   {{_input("date", name, label, required, hint)}}
 {% endmacro %}
 
-{% macro textArea(name, label, required, hint) %}
+{% macro textArea(name, label, required, hint, linkHint, link) %}
   <p>
     <label for="{{name}}">
       {{label}}
@@ -21,6 +21,9 @@
     <textarea id="{{name}}" name="{{name}}" rows=10 {%if required %}required{%endif%}></textarea>
     {% if hint %}
       <span class="hint">{{hint}}</span>
+    {% endif %}
+    {% if linkHint %}
+      <span class="hint">{{linkHint}} {% if link %}<a href="{{link}}" target="_blank">{{link}}</a>{% endif %}</span>
     {% endif %}
     <span class="error"></span>
   </p>


### PR DESCRIPTION
Added _linkHint_, new type of hint at the form template, and used to place the Markdown cheat sheet in new events description.