### PR TITLE
Add past events

### DIFF
--- a/build.js
+++ b/build.js
@@ -4,6 +4,7 @@ const layouts = require('metalsmith-layouts')
 const permalinks = require('metalsmith-permalinks')
 const inplace = require('metalsmith-in-place')
 const collections = require('metalsmith-collections')
+const pagination = require('metalsmith-pagination')
 const uglify = require('metalsmith-uglify')
 const sass = require('metalsmith-sass')
 const writemetadata = require('metalsmith-writemetadata')
@@ -47,6 +48,17 @@ Metalsmith(__dirname)
       jobs: { sortBy: 'publishedAt', reverse: true },
       events: { sortBy: 'startDate' },
       pastevents: { sortBy: 'startDate', reverse: true }
+    })
+  )
+  .use(
+    pagination({
+      'collections.pastevents': {
+        perPage: 30,
+        layout: 'past-events.njk',
+        first: 'events/past/index.html',
+        noPageOne: true,
+        path: 'events/past/page/:num/index.html'
+      }
     })
   )
   .use(markdown({ sanitize: true }))

--- a/build.js
+++ b/build.js
@@ -130,7 +130,6 @@ Metalsmith(__dirname)
     writemetadata({
       collections: {
         events: { output: { path: '.events-published.json' }, ignorekeys: ['contents', 'next', 'previous'] },
-        pastevents: { output: { path: '.past-events-published.json' }, ignorekeys: ['contents', 'next', 'previous'] },
         jobs: { output: { path: '.jobs-published.json' }, ignorekeys: ['contents', 'next', 'previous'] }
       }
     })

--- a/build.js
+++ b/build.js
@@ -39,12 +39,14 @@ Metalsmith(__dirname)
   .source('./data')
   .destination('./dist')
   .clean(true)
-  .use(events({ apiRoot: apiRoot, collection: 'events' }))
+  .use(events.upcoming({ apiRoot: apiRoot, collection: 'events' }))
+  .use(events.past({ apiRoot: apiRoot, collection: 'pastevents' }))
   .use(jobs({ apiRoot: apiRoot, collection: 'jobs' }))
   .use(
     collections({
       jobs: { sortBy: 'publishedAt', reverse: true },
-      events: { sortBy: 'startDate' }
+      events: { sortBy: 'startDate' },
+      pastevents: { sortBy: 'startDate', reverse: true }
     })
   )
   .use(markdown({ sanitize: true }))
@@ -116,6 +118,7 @@ Metalsmith(__dirname)
     writemetadata({
       collections: {
         events: { output: { path: '.events-published.json' }, ignorekeys: ['contents', 'next', 'previous'] },
+        pastevents: { output: { path: '.past-events-published.json' }, ignorekeys: ['contents', 'next', 'previous'] },
         jobs: { output: { path: '.jobs-published.json' }, ignorekeys: ['contents', 'next', 'previous'] }
       }
     })

--- a/data/assets/css/components/_button.scss
+++ b/data/assets/css/components/_button.scss
@@ -43,3 +43,15 @@
     background-color: $black;
   }
 }
+
+.chevron-left-icon,
+.chevron-rigth-icon,
+.chevron-first-icon,
+.chevron-last-icon {
+  width: 2.75rem;
+}
+
+.chevron-rigth-icon,
+.chevron-last-icon {
+  transform: rotate(180deg);
+}

--- a/data/assets/css/components/_event-summary.scss
+++ b/data/assets/css/components/_event-summary.scss
@@ -1,4 +1,5 @@
-.next-events-summary {
+.next-events-summary,
+.past-events-summary {
   display: grid;
   grid-template-columns: 1fr;
 

--- a/data/assets/css/pages/_event-next.scss
+++ b/data/assets/css/pages/_event-next.scss
@@ -1,4 +1,5 @@
-#next-events {
+#next-events,
+#past-events {
   > header {
     display: flex;
     justify-content: space-between;

--- a/data/assets/css/pages/_event-next.scss
+++ b/data/assets/css/pages/_event-next.scss
@@ -2,9 +2,13 @@
 #past-events {
   > header {
     display: flex;
-    justify-content: space-between;
-    align-items: baseline;
     flex-direction: column-reverse;
+    align-items: baseline;
+    justify-content: space-between;
+
+    @include size-medium {
+      flex-direction: row;
+    }
 
     .header-contain-left {
       display: flex;
@@ -22,8 +26,8 @@
     .rss-text {
       position: absolute;
       padding-left: 0.75rem;
-      transform-origin: left;
       transform: scale(0);
+      transform-origin: left;
       transition: 350ms;
     }
 
@@ -32,12 +36,9 @@
       transform: unset !important;
     }
 
-    @include size-medium {
-      flex-direction: row;
-    }
-
     .button {
-      margin: 4rem 0 1.5rem 0;
+      margin: 4rem 0 1.5rem;
+
       @include size-medium {
         margin: 0;
       }

--- a/data/assets/css/pages/_event-next.scss
+++ b/data/assets/css/pages/_event-next.scss
@@ -43,4 +43,20 @@
       }
     }
   }
+
+  .pagination {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: center;
+
+    > a,
+    > span {
+      margin: 0 $space-small;
+    }
+
+    > .pag-disabled {
+      opacity: .5;
+    }
+  }
 }

--- a/data/assets/css/pages/_event-next.scss
+++ b/data/assets/css/pages/_event-next.scss
@@ -57,7 +57,7 @@
     }
 
     > .pag-disabled {
-      opacity: .5;
+      opacity: 0.5;
     }
   }
 }

--- a/data/assets/img/chevron-circle-left.svg
+++ b/data/assets/img/chevron-circle-left.svg
@@ -1,14 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="512pt" height="512pt" version="1.1" viewBox="0 0 512.00002 512.00002" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-<metadata>
-<rdf:RDF>
-<cc:Work rdf:about="">
-<dc:format>image/svg+xml</dc:format>
-<dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-<dc:title/>
-</cc:Work>
-</rdf:RDF>
-</metadata>
-<path class="circle" transform="scale(.75)" d="m340 2.666a340 340 0 0 0 -340 340 340 340 0 0 0 340 340 340 340 0 0 0 340 -340 340 340 0 0 0 -340 -340zm0 53a287 287 0 0 1 287 287 287 287 0 0 1 -287 287 287 287 0 0 1 -287 -287 287 287 0 0 1 287 -287z" stroke-width="1.1333"/>
+<svg width="512pt" height="512pt" version="1.1" viewBox="0 0 512.00002 512.00002" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:osb="http://www.openswatchbook.org/uri/2009/osb" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+<circle cx="255" cy="257" r="235.45" fill-opacity="0" stroke="#000" stroke-width="39.108"/>
 <path class="chevron" d="m151.72 256 147.28-147.29 28.286 28.285-119 119 119 119-28.286 28.285z" stroke="#000" stroke-width=".75px"/>
 </svg>

--- a/data/assets/img/chevron-circle-left.svg
+++ b/data/assets/img/chevron-circle-left.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="512pt" height="512pt" version="1.1" viewBox="0 0 512.00002 512.00002" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+<metadata>
+<rdf:RDF>
+<cc:Work rdf:about="">
+<dc:format>image/svg+xml</dc:format>
+<dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+<dc:title/>
+</cc:Work>
+</rdf:RDF>
+</metadata>
+<path class="circle" transform="scale(.75)" d="m340 2.666a340 340 0 0 0 -340 340 340 340 0 0 0 340 340 340 340 0 0 0 340 -340 340 340 0 0 0 -340 -340zm0 53a287 287 0 0 1 287 287 287 287 0 0 1 -287 287 287 287 0 0 1 -287 -287 287 287 0 0 1 287 -287z" stroke-width="1.1333"/>
+<path class="chevron" d="m151.72 256 147.28-147.29 28.286 28.285-119 119 119 119-28.286 28.285z" stroke="#000" stroke-width=".75px"/>
+</svg>

--- a/data/assets/img/chevron-circle-start-left.svg
+++ b/data/assets/img/chevron-circle-start-left.svg
@@ -1,15 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="512pt" height="512pt" version="1.1" viewBox="0 0 512.00002 512.00002" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-<metadata>
-<rdf:RDF>
-<cc:Work rdf:about="">
-<dc:format>image/svg+xml</dc:format>
-<dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-<dc:title/>
-</cc:Work>
-</rdf:RDF>
-</metadata>
-<path class="circle" transform="scale(.75)" d="m340 2.666a340 340 0 0 0 -340 340 340 340 0 0 0 340 340 340 340 0 0 0 340 -340 340 340 0 0 0 -340 -340zm0 53a287 287 0 0 1 287 287 287 287 0 0 1 -287 287 287 287 0 0 1 -287 -287 287 287 0 0 1 287 -287z" stroke-width="1.1333"/>
+<svg width="512pt" height="512pt" version="1.1" viewBox="0 0 512.00002 512.00002" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:osb="http://www.openswatchbook.org/uri/2009/osb" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+<circle cx="255" cy="257" r="235.45" fill-opacity="0" stroke="#000" stroke-width="39.108"/>
 <path class="chevron" d="m189.22 256 147.28-147.29 28.286 28.285-119 119 119 119-28.286 28.285z" stroke="#000" stroke-width=".75px"/>
-<path class="stick" d="m153.88 402.52-7e-3 -294.46h40.002c-0.41622 118.94 1e-3 167.54-2.6e-4 294.46z" stroke="#000" stroke-width=".89174px"/>
+<path class="stick" d="m153.88 402.52-7e-3 -294.46h40.002c-0.41622 118.94 1e-3 167.54-2.6e-4 294.46z" stroke="#000" stroke-width=".75"/>
 </svg>

--- a/data/assets/img/chevron-circle-start-left.svg
+++ b/data/assets/img/chevron-circle-start-left.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="512pt" height="512pt" version="1.1" viewBox="0 0 512.00002 512.00002" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+<metadata>
+<rdf:RDF>
+<cc:Work rdf:about="">
+<dc:format>image/svg+xml</dc:format>
+<dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+<dc:title/>
+</cc:Work>
+</rdf:RDF>
+</metadata>
+<path class="circle" transform="scale(.75)" d="m340 2.666a340 340 0 0 0 -340 340 340 340 0 0 0 340 340 340 340 0 0 0 340 -340 340 340 0 0 0 -340 -340zm0 53a287 287 0 0 1 287 287 287 287 0 0 1 -287 287 287 287 0 0 1 -287 -287 287 287 0 0 1 287 -287z" stroke-width="1.1333"/>
+<path class="chevron" d="m189.22 256 147.28-147.29 28.286 28.285-119 119 119 119-28.286 28.285z" stroke="#000" stroke-width=".75px"/>
+<path class="stick" d="m153.88 402.52-7e-3 -294.46h40.002c-0.41622 118.94 1e-3 167.54-2.6e-4 294.46z" stroke="#000" stroke-width=".89174px"/>
+</svg>

--- a/data/events/past.njk
+++ b/data/events/past.njk
@@ -1,0 +1,31 @@
+{% set pageTitle = "Eventos pasados" %}
+{% set navItem = "events" %}
+
+{% extends "./templates/default.njk" %}
+{% from "./templates/macros/event.njk" import image, dayOfWeek, time, shortCompleteDate %}
+
+{% block main %}
+  <article id="past-events">
+    <header>
+      <h1 class="title"> Eventos pasados </h1>
+    </header>
+    <section class="past-events-summary">
+      {% for event in collections.pastevents %}
+       <article class="event-summary">
+       <h1>
+        <a href="/events/{{event.slug}}">
+          <section class="reset-link">{{image(event.twitter)}}</section>
+          {{event.title}}
+        </a>
+        </h1>
+        <p>
+          {{ dayOfWeek(event.startDate) }} /
+          {{ shortCompleteDate(event.startDate) }} /
+          {{ time(event.startDate) }}
+          </p>
+        <hr>
+      </article>
+      {% endfor %}
+    </section>
+  </article>
+{% endblock %}

--- a/data/index.njk
+++ b/data/index.njk
@@ -30,8 +30,10 @@
           {{ dayOfWeek(event.startDate) }} /
           {{ shortDate(event.startDate) }} /
           {{ time(event.startDate) }}
-          <br>
-          {{event.organizer}}
+          {% if event.organizer %}
+            <br>
+            {{event.organizer}}
+          {% endif %}
           </p>
         <hr>
       </article>

--- a/lib/events.js
+++ b/lib/events.js
@@ -79,6 +79,7 @@ module.exports.past = (options = {}) => {
   const config = {
     resource: 'past',
     collection: 'pastevents',
+    layout: 'past-event.njk',
     ...options
   }
 

--- a/lib/events.js
+++ b/lib/events.js
@@ -13,55 +13,76 @@ const createTwitterInfo = function(txt) {
   return twitter
 }
 
-module.exports = (options = {}) => {
-  const { apiRoot, collection, layout } = {
+const events = function(options, files, metalsmith, done) {
+  const { apiRoot, resource, collection, layout } = {
     apiRoot: 'uri-goes-here',
-    collection: 'events',
     layout: 'event.njk',
     ...options
   }
 
-  return function(files, metalsmith, done) {
-    let url = `${apiRoot}/events/upcoming`
+  let url = `${apiRoot}/events/${resource}`
 
-    console.log('Consuming', url)
+  console.log('Consuming', url)
 
-    let protocol = apiRoot.startsWith('https://') ? https : http
-    const req = protocol.get(url, res => {
-      let body = ''
-      res.on('data', chunk => {
-        body += chunk
-      })
-      res.on('end', () => {
-        let events = JSON.parse(body)
-        events.forEach(e => {
-          let page = {
-            id: e.id,
-            file: 'events/' + e.slug + '.md',
-            layout: layout,
-            collection: collection,
-            title: e.title,
-            contents: Buffer.from(e.description),
-            startDate: e.date.toString(),
-            organizer: e.hashtag,
-            twitter: createTwitterInfo(e.hashtag),
-            slug: e.slug,
-            sourceUrl: e.link,
-            pageTitle: e.title,
-            seo: {
-              ogTitle: e.title,
-              ogDescription: e.description,
-              ogUrl: apiRoot + 'events/' + e.slug + '/'
-            }
+  let protocol = apiRoot.startsWith('https://') ? https : http
+  const req = protocol.get(url, res => {
+    let body = ''
+    res.on('data', chunk => {
+      body += chunk
+    })
+    res.on('end', () => {
+      let events = JSON.parse(body)
+      events.forEach(e => {
+        let page = {
+          id: e.id,
+          file: 'events/' + e.slug + '.md',
+          layout: layout,
+          collection: collection,
+          title: e.title,
+          contents: Buffer.from(e.description),
+          startDate: e.date.toString(),
+          organizer: e.hashtag,
+          twitter: createTwitterInfo(e.hashtag),
+          slug: e.slug,
+          sourceUrl: e.link,
+          pageTitle: e.title,
+          seo: {
+            ogTitle: e.title,
+            ogDescription: e.description,
+            ogUrl: apiRoot + 'events/' + e.slug + '/'
           }
-          files[page.file] = page
-        })
-        done()
+        }
+        files[page.file] = page
       })
+      done()
     })
-    req.on('error', error => {
-      console.error(error)
-    })
-    req.end()
+  })
+  req.on('error', error => {
+    console.error(error)
+  })
+  req.end()
+}
+
+module.exports.upcoming = (options = {}) => {
+  const config = {
+    resource: 'upcoming',
+    collection: 'events',
+    ...options
+  }
+
+  return function(files, metalsmith, done) {
+    return events(config, files, metalsmith, done)
+  }
+}
+
+module.exports.past = (options = {}) => {
+  const config = {
+    resource: 'past',
+    collection: 'pastevents',
+    ...options
+  }
+
+  return function(files, metalsmith, done) {
+    return events(config, files, metalsmith, done)
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "metalsmith-in-place": "^4.4.0",
     "metalsmith-layouts": "^2.3.1",
     "metalsmith-markdown": "^1.2.0",
+    "metalsmith-pagination": "^1.4.1",
     "metalsmith-permalinks": "^2.2.0",
     "metalsmith-sass": "^1.6.0",
     "metalsmith-uglify": "^2.3.2",

--- a/templates/event.njk
+++ b/templates/event.njk
@@ -5,7 +5,7 @@
   <article id="event-page">
   <header>
     <h1>{{title}}</h1>
-    <p>{{longDate(startDate)}} | {{time(startDate)}} | {{organizer}} </p>
+    <p>{{longDate(startDate)}} | {{time(startDate)}} {% if organizer %}| {{organizer}} {% endif %}</p>
   </header>
     <section class="event-details">
       {{ image(twitter) }}

--- a/templates/layout/footer.njk
+++ b/templates/layout/footer.njk
@@ -4,6 +4,7 @@
       <h1>Eventos</h1>
       <ul>
         <li><a href="/">Próximos eventos</a></li>
+        <li><a href="/events/past/">Eventos pasados</a></li>
         <li><a href="/events/new/">Publicar evento</a></li>
         <li><a href="https://addons.mozilla.org/en-US/firefox/addon/vlctechhub-publisher-addon/">Firefox extension</a>
         <li><a href="https://chrome.google.com/webstore/detail/vlctechhub-publisher-addo/jmphppchcbgfglglfbemgbjligclmcmc">Chrome extension</a></li>

--- a/templates/macros/event.njk
+++ b/templates/macros/event.njk
@@ -23,6 +23,10 @@
   {{d | newDate | date('DD MMMM YYYY') | capitalize }}
 {% endmacro %}
 
+{% macro longCompleteDate(d) %}
+  {{d | newDate | date('dddd DD [de] MMMM [de] YYYY') | capitalize }}
+{% endmacro %}
+
 {% macro time(d) %}
   {{d | newDate | date('tz', 'Europe/Madrid') | date('HH:mm')}}h
 {% endmacro %}

--- a/templates/macros/event.njk
+++ b/templates/macros/event.njk
@@ -19,6 +19,10 @@
   {{d | newDate | date('dddd DD [de] MMMM') | capitalize }}
 {% endmacro %}
 
+{% macro shortCompleteDate(d) %}
+  {{d | newDate | date('DD MMMM YYYY') | capitalize }}
+{% endmacro %}
+
 {% macro time(d) %}
   {{d | newDate | date('tz', 'Europe/Madrid') | date('HH:mm')}}h
 {% endmacro %}

--- a/templates/past-event.njk
+++ b/templates/past-event.njk
@@ -5,7 +5,7 @@
   <article id="event-page">
   <header>
     <h1>{{title}}</h1>
-    <p>{{longCompleteDate(startDate)}} | {{time(startDate)}}</p>
+    <p>{{longCompleteDate(startDate)}} | {{time(startDate)}} | {{organizer}}</p>
   </header>
     <section class="event-details">
       {{ image(twitter) }}

--- a/templates/past-event.njk
+++ b/templates/past-event.njk
@@ -5,7 +5,7 @@
   <article id="event-page">
   <header>
     <h1>{{title}}</h1>
-    <p>{{longCompleteDate(startDate)}} | {{time(startDate)}} | {{organizer}}</p>
+    <p>{{longCompleteDate(startDate)}} | {{time(startDate)}} {% if organizer %}| {{organizer}} {% endif %}</p>
   </header>
     <section class="event-details">
       {{ image(twitter) }}

--- a/templates/past-event.njk
+++ b/templates/past-event.njk
@@ -1,0 +1,24 @@
+{% extends "./default.njk" %}
+{% from "./macros/event.njk" import image, longCompleteDate, time %}
+
+{% block main %}
+  <article id="event-page">
+  <header>
+    <h1>{{title}}</h1>
+    <p>{{longCompleteDate(startDate)}} | {{time(startDate)}}</p>
+  </header>
+    <section class="event-details">
+      {{ image(twitter) }}
+      <section class="details">
+      <p>{{longCompleteDate(startDate)}}</p>
+      <p>{{time(startDate)}}</p>
+      </section>
+      <section class="actions">
+      <a href="{{sourceUrl}}" class="button button-primary">Ver fuente</a>
+      </section>
+    </section>
+    <section class="event-description">
+      {{contents | safe}}
+    </section>
+  </article>
+{% endblock %}

--- a/templates/past-events.njk
+++ b/templates/past-events.njk
@@ -22,8 +22,10 @@
           {{ dayOfWeek(event.startDate) }} /
           {{ shortCompleteDate(event.startDate) }} /
           {{ time(event.startDate) }}
-          <br>
-          {{event.organizer}}
+          {% if event.organizer %}
+            <br>
+            {{event.organizer}}
+          {% endif %}
           </p>
         <hr>
       </article>

--- a/templates/past-events.njk
+++ b/templates/past-events.njk
@@ -27,16 +27,26 @@
       </article>
       {% endfor %}
     </section>
-    <nav>
-      <a href={{'/' + pagination.first.path}}>Primera</a>
-      {% if pagination.previous %}
-        <a href={{'/' + pagination.previous.path}}>Anterior</a>
-      {% endif %}
+    <nav class="pagination">
+
+      {% if pagination.num !== 1 %}<a href={{'/' + pagination.first.path}}>{% else %}<span class="pag-disabled">{% endif %}
+        <img class="chevron-first-icon" src="/assets/img/chevron-circle-start-left.svg" alt="Ir a la página inicial">
+      {% if pagination.num !== 1 %}</a>{% else %}</span>{% endif %}
+
+      {% if pagination.previous %}<a href={{'/' + pagination.previous.path}}>{% else %}<span class="pag-disabled">{% endif %}
+        <img class="chevron-left-icon" src="/assets/img/chevron-circle-left.svg" alt="Ir a la página anterior">
+      {% if pagination.previous %}</a>{% else %}</span>{% endif %}
+
       <span>{{ pagination.num + ' de ' + pagination.pages.length }}</span>
-      {% if pagination.next %}
-        <a href={{'/' + pagination.next.path}}>Siguiente</a>
-      {% endif %}
-      <a href={{'/' + pagination.last.path}}>Última</a>
+
+      {% if pagination.next %}<a href={{'/' + pagination.next.path}}>{% else %}<span class="pag-disabled">{% endif %}
+        <img class="chevron-rigth-icon" src="/assets/img/chevron-circle-left.svg" alt="Ir a la página siguiente">
+      {% if pagination.next %}</a>{% else %}</span>{% endif %}
+      
+      {% if pagination.num !== pagination.pages.length %}<a href={{'/' + pagination.last.path}}>{% else %}<span class="pag-disabled">{% endif %}
+        <img class="chevron-last-icon" src="/assets/img/chevron-circle-start-left.svg" alt="Ir a la última página">
+      {% if pagination.num !== pagination.pages.length %}</a>{% else %}</span>{% endif %}
+
     </nav>
   </article>
 {% endblock %}

--- a/templates/past-events.njk
+++ b/templates/past-events.njk
@@ -1,8 +1,8 @@
 {% set pageTitle = "Eventos pasados" %}
 {% set navItem = "events" %}
 
-{% extends "./templates/default.njk" %}
-{% from "./templates/macros/event.njk" import image, dayOfWeek, time, shortCompleteDate %}
+{% extends "./default.njk" %}
+{% from "./macros/event.njk" import image, dayOfWeek, time, shortCompleteDate %}
 
 {% block main %}
   <article id="past-events">
@@ -10,7 +10,7 @@
       <h1 class="title"> Eventos pasados </h1>
     </header>
     <section class="past-events-summary">
-      {% for event in collections.pastevents %}
+      {% for event in pagination.files %}
        <article class="event-summary">
        <h1>
         <a href="/events/{{event.slug}}">
@@ -27,5 +27,16 @@
       </article>
       {% endfor %}
     </section>
+    <nav>
+      <a href={{'/' + pagination.first.path}}>Primera</a>
+      {% if pagination.previous %}
+        <a href={{'/' + pagination.previous.path}}>Anterior</a>
+      {% endif %}
+      <span>{{ pagination.num + ' de ' + pagination.pages.length }}</span>
+      {% if pagination.next %}
+        <a href={{'/' + pagination.next.path}}>Siguiente</a>
+      {% endif %}
+      <a href={{'/' + pagination.last.path}}>Última</a>
+    </nav>
   </article>
 {% endblock %}

--- a/templates/past-events.njk
+++ b/templates/past-events.njk
@@ -22,6 +22,8 @@
           {{ dayOfWeek(event.startDate) }} /
           {{ shortCompleteDate(event.startDate) }} /
           {{ time(event.startDate) }}
+          <br>
+          {{event.organizer}}
           </p>
         <hr>
       </article>
@@ -42,7 +44,7 @@
       {% if pagination.next %}<a href={{'/' + pagination.next.path}}>{% else %}<span class="pag-disabled">{% endif %}
         <img class="chevron-rigth-icon" src="/assets/img/chevron-circle-left.svg" alt="Ir a la página siguiente">
       {% if pagination.next %}</a>{% else %}</span>{% endif %}
-      
+
       {% if pagination.num !== pagination.pages.length %}<a href={{'/' + pagination.last.path}}>{% else %}<span class="pag-disabled">{% endif %}
         <img class="chevron-last-icon" src="/assets/img/chevron-circle-start-left.svg" alt="Ir a la última página">
       {% if pagination.num !== pagination.pages.length %}</a>{% else %}</span>{% endif %}

--- a/yarn.lock
+++ b/yarn.lock
@@ -755,6 +755,11 @@ component-emitter@^1.2.1:
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
   integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
 
+component-props@*:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/component-props/-/component-props-1.1.1.tgz#f9b7df9b9927b6e6d97c9bd272aa867670f34944"
+  integrity sha1-+bffm5kntubZfJvScqqGdnDzSUQ=
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -2392,6 +2397,14 @@ metalsmith-markdown@^1.2.0:
     debug "^4.1.1"
     marked "^0.6.1"
 
+metalsmith-pagination@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/metalsmith-pagination/-/metalsmith-pagination-1.4.1.tgz#5b83ca19ed8cb0b5b2ccd403fbcb80a4c2d4074e"
+  integrity sha512-K7VjuKzIiP9Jw+1D7q0ChbfzLtl3arMpkYaztR6mFfOIs+ujMENhivvt1Kg1PwK6WXG4RXcew+oWLjwJJ5YqGw==
+  dependencies:
+    to-function "^2.0.5"
+    xtend "^4.0.0"
+
 metalsmith-permalinks@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/metalsmith-permalinks/-/metalsmith-permalinks-2.2.0.tgz#11df50e79377b5d60c02c93ebba2a85bf069f5fc"
@@ -3989,6 +4002,13 @@ to-fast-properties@^1.0.3:
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
   integrity sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=
 
+to-function@^2.0.5:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/to-function/-/to-function-2.0.6.tgz#7d56cd9c3b92fa8dbd7b22e83d51924de740ebc5"
+  integrity sha1-fVbNnDuS+o29eyLoPVGSTedA68U=
+  dependencies:
+    component-props "*"
+
 to-object-path@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/to-object-path/-/to-object-path-0.3.0.tgz#297588b7b0e7e0ac08e04e672f85c1f4999e17af"
@@ -4318,6 +4338,11 @@ xml-js@^1.6.11:
   integrity sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==
   dependencies:
     sax "^1.2.4"
+
+xtend@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
+  integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
 
 y18n@^3.2.0, y18n@^3.2.1:
   version "3.2.1"


### PR DESCRIPTION
It adds past events to the site. It includes a page listing all past event with pagination and a detail page for every past event. 

All past events are generated into the site, if only are needed the events starting from 2017, maybe the easiest way is to add a start date param to api.vlctechhub.org/v2/events/past, which it's the resource consumed.

- [x] Past events page.
- [x] Pagination.
- [x] Past event detail page.

Closes #66.