### PR TITLE
#84: Fix too long titles

### DIFF
--- a/data/assets/css/components/_event-summary.scss
+++ b/data/assets/css/components/_event-summary.scss
@@ -16,6 +16,7 @@
   position: relative;
   justify-self: left;
   margin-bottom: $space-large;
+  max-width: 300px;
 
   @include size-medium {
     justify-self: center;


### PR DESCRIPTION
Added a max width to the events to that the text does not extend the width of the image of the event.