### PR TITLE
#83: Added Check for empty link

### DIFF
--- a/templates/job.njk
+++ b/templates/job.njk
@@ -28,7 +28,7 @@
       <h2>Cómo aplicar</h2>
       {{howToApply | safe }}
       </section>
-      {% if sourceUrl %}
+      {% if sourceUrl !== "http://" %}
       <section>
       <h2>Más infomación</h2>
       <p>Más información de la oferta en <a href="{{sourceUrl}}">{{sourceUrl}}</a>.</p>


### PR DESCRIPTION
As you can see in the changes the fix required me to check explicitly for "http://" in the sourceUrl. I could not find a place where the "http://" gets prepended so i assume the problem lies in the API. 

So it depends on if you want to change the API or the frontend in that case.