### PR TITLE
used email input type on the email field of the job submission form

### DIFF
--- a/data/assets/css/components/_form.scss
+++ b/data/assets/css/components/_form.scss
@@ -21,6 +21,7 @@ form {
 input[type='text'],
 input[type='time'],
 input[type='date'],
+input[type='email'],
 textarea,
 fieldset {
   padding: $space-small;
@@ -41,6 +42,7 @@ form[data-submit-attempted='true'] {
   input[type='text'],
   input[type='time'],
   input[type='date'],
+  input[type='email'],
   textarea,
   fieldset {
     &:invalid {

--- a/data/job/new.njk
+++ b/data/job/new.njk
@@ -1,7 +1,7 @@
 {% set pageTitle = "Publicar oferta" %}
 {% extends "./templates/default.njk" %}
 
-{% from "./templates/macros/form.njk" import textInput, textArea %}
+{% from "./templates/macros/form.njk" import textInput, textArea, emailInput %}
 
 {% block main %}
   <article id="new-job">
@@ -31,7 +31,7 @@
     {{textInput('companyName', 'Nombre de la empresa', required)}}
     {{textInput('companyWeb', 'Web de la empresa', required)}}
     {{textInput('companyTwitter', 'Twitter de la empresa', notRequired, "Te nombraremos cuando se publique la oferta. Ej: @mozilla")}}
-    {{textInput('companyContact', 'Email de contacto', required, "Email contacto en caso de tener alguna duda con la oferta. Este email no se publicará con la oferta.")}}
+    {{emailInput('companyContact', 'Email de contacto', required, "Email contacto en caso de tener alguna duda con la oferta. Este email no se publicará con la oferta.")}}
     <button type="button" class="button button-emphasis" data-type="submit">Enviar la oferta</button>
   </form>
   </article>

--- a/templates/macros/form.njk
+++ b/templates/macros/form.njk
@@ -2,6 +2,10 @@
   {{_input("text", name, label, required, hint)}}
 {% endmacro %}
 
+{% macro emailInput(name, label, required, hint) %}
+  {{_input("email", name, label, required, hint)}}
+{% endmacro %}
+
 {% macro timeInput(name, label, required, hint) %}
   {{_input("time", name, label, required, hint)}}
 {% endmacro %}


### PR DESCRIPTION
I have modified and used the email input type on the email field of the job submission form.

1. I have modified the template form.njk to have validation on the email input type.
2. I have modified the new.njk to use the "emailInput" for the email field that I created.
3. I have modified the _form.scss to include the email input to have the same styles as other input fields.

Tested with the following input on the email field:
1. testemail (successfully validated as it is not an email input).
2. testemail@ (successfully validated as it is not an email input).
3. testemail@g (The form treats this as a valid email input, not sure if this naturally behaves like this).