### PR TITLE
Reschedule site publishing

### DIFF
--- a/.github/workflows/site-refresh.yml
+++ b/.github/workflows/site-refresh.yml
@@ -3,7 +3,7 @@ name: Refresh site in Surge
 on:
   repository_dispatch:
   schedule:
-    - cron: "*/15 * * * *"
+    - cron: "*/15 7-23 * * *"
 
 jobs:
   refresh:


### PR DESCRIPTION
Until we sort out if an on demand publishing scheme is more desirable, this restricts site publishing from 7:00 UTC to 23:00 UTC.

Closes #110.