### PR TITLE
Configure input date fallback

### DIFF
--- a/data/assets/js/events-new.js
+++ b/data/assets/js/events-new.js
@@ -2,17 +2,17 @@ Site.Events = Site.Events || {}
 Site.Events.New = {}
 Site.Events.New.init = function() {
   let DST = {
-    2019: { start: new Date(2019, 2, 31), end: new Date(2019, 9, 27) },
-    2020: { start: new Date(2020, 2, 29), end: new Date(2020, 9, 25) },
-    2021: { start: new Date(2021, 2, 28), end: new Date(2021, 9, 31) },
-    2022: { start: new Date(2022, 2, 27), end: new Date(2022, 9, 30) },
-    2023: { start: new Date(2023, 2, 26), end: new Date(2023, 9, 29) },
-    2024: { start: new Date(2024, 2, 31), end: new Date(2024, 9, 27) },
-    2025: { start: new Date(2025, 2, 30), end: new Date(2025, 9, 26) },
-    2026: { start: new Date(2026, 2, 29), end: new Date(2026, 9, 25) },
-    2027: { start: new Date(2027, 2, 28), end: new Date(2027, 9, 31) },
-    2028: { start: new Date(2028, 2, 26), end: new Date(2028, 9, 29) },
-    2029: { start: new Date(2029, 2, 25), end: new Date(2029, 9, 28) }
+    2019: { start: new Date(2019, 2, 31, 2), end: new Date(2019, 9, 27, 3) },
+    2020: { start: new Date(2020, 2, 29, 2), end: new Date(2020, 9, 25, 3) },
+    2021: { start: new Date(2021, 2, 28, 2), end: new Date(2021, 9, 31, 3) },
+    2022: { start: new Date(2022, 2, 27, 2), end: new Date(2022, 9, 30, 3) },
+    2023: { start: new Date(2023, 2, 26, 2), end: new Date(2023, 9, 29, 3) },
+    2024: { start: new Date(2024, 2, 31, 2), end: new Date(2024, 9, 27, 3) },
+    2025: { start: new Date(2025, 2, 30, 2), end: new Date(2025, 9, 26, 3) },
+    2026: { start: new Date(2026, 2, 29, 2), end: new Date(2026, 9, 25, 3) },
+    2027: { start: new Date(2027, 2, 28, 2), end: new Date(2027, 9, 31, 3) },
+    2028: { start: new Date(2028, 2, 26, 2), end: new Date(2028, 9, 29, 3) },
+    2029: { start: new Date(2029, 2, 25, 2), end: new Date(2029, 9, 28, 3) }
   }
 
   function $E(selector) {
@@ -23,7 +23,7 @@ Site.Events.New.init = function() {
     let utcOffset = 1
 
     let dst = DST[date.getUTCFullYear()]
-    if (dst && date > dst.start && date < dst.end) {
+    if (dst && date >= dst.start && date < dst.end) {
       utcOffset = 2
     }
     return utcOffset

--- a/data/events/new.njk
+++ b/data/events/new.njk
@@ -23,7 +23,7 @@
     <form onsubmit="return false;">
     {% set required = true %}
     {{textInput('title', 'Título', required)}}
-    {{dateInput('startDate', 'Fecha', required)}}
+    {{dateInput('startDate', 'Fecha', required, 'Si tu navegador no soporta el control de tipo fecha, escríbela utilizando el formato yyyy-mm-dd.')}}
     {{timeInput('startTime', 'Hora', required, 'Formato hh:mm. Si el control pide tres valores, el tercer valor establece AM o PM.')}}
     {{textArea('description', 'Descripción', required, '', 'Admite el uso de Markdown', 'https://www.markdownguide.org/cheat-sheet/')}}
     {{textInput('sourceUrl', 'Link', required)}}

--- a/templates/macros/form.njk
+++ b/templates/macros/form.njk
@@ -11,7 +11,7 @@
 {% endmacro %}
 
 {% macro dateInput(name, label, required, hint) %}
-  {{_input("date", name, label, required, hint)}}
+  {{_input("date", name, label, required, hint, '(?:19|20)[0-9]{2}-(?:(?:0[1-9]|1[0-2])-(?:0[1-9]|1[0-9]|2[0-9])|(?:(?!02)(?:0[1-9]|1[0-2])-(?:30))|(?:(?:0[13578]|1[02])-31))')}}
 {% endmacro %}
 
 {% macro textArea(name, label, required, hint, linkHint, link) %}
@@ -22,7 +22,7 @@
         <abbr title="Campo obligatorio">*</abbr>
       {% endif %}
     </label>
-    <textarea id="{{name}}" name="{{name}}" rows=10 {%if required %}required{%endif%}></textarea>
+    <textarea id="{{name}}" name="{{name}}" rows=10 {% if required %}required{% endif %}></textarea>
     {% if hint %}
       <span class="hint">{{hint}}</span>
     {% endif %}
@@ -33,7 +33,7 @@
   </p>
 {% endmacro %}
 
-{% macro _input(type, name, label, required, hint) %}
+{% macro _input(type, name, label, required, hint, pattern) %}
   <p>
     <label for="{{name}}">
       <span>{{label}}</span>
@@ -41,7 +41,7 @@
         <abbr title="Campo obligatorio">*</abbr>
       {% endif %}
     </label>
-    <input id="{{name}}" name="{{name}}" type="{{type}}" {%if required %}required{%endif%}></input>
+    <input id="{{name}}" name="{{name}}" type="{{type}}" {% if required %}required{% endif %} {% if pattern %}pattern="{{pattern}}"{% endif %}></input>
     {% if hint %}
       <span class="hint">{{hint}}</span>
     {% endif %}


### PR DESCRIPTION
If the browser doesn't support the `date` input type,  the input [falls back](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/date#Validation) to type `text`. In those cases there's no hint on how the date value is expected.

This configures a hint text and a `pattern` attribute to enforce the ISO8601 format —which is what is expected from the form field— if the input falls back to the `text` type.

It also resolves a recurrent problem with UTC offset not properly computed for submissions coming from browsers not supporting the `date` type: when the date value is not in the proper format the UTC offset defaults to 1, but if the API endpoint is still capable of parsing the date format the value is stored with the wrong offset.